### PR TITLE
Fixes composer requirements for TYPO3 10.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/mime": "^4.4 || ^5.0",
         "goldspecdigital/oooas": "^2.4",
         "phpdocumentor/reflection-docblock": "^5.1",
-        "doctrine/annotations": "^1.0"
+        "doctrine/annotations": "^1.0",
+	"doctrine/cache": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",


### PR DESCRIPTION
Bug: Class 'Doctrine\Common\Cache\FilesystemCache' not found

class: \SourceBroker\T3api\Service\SerializerService uses FilesystemCache which has been removed in doctrine/cache:^2.0
From doctrine/dbal 2.13.1 doctrine/cache:^2.0 is required and throws error.