### PR TITLE
[FEATURE] PHP 8.0 compatibility

### DIFF
--- a/Classes/Serializer/Subscriber/AbstractEntitySubscriber.php
+++ b/Classes/Serializer/Subscriber/AbstractEntitySubscriber.php
@@ -129,7 +129,7 @@ class AbstractEntitySubscriber implements EventSubscriberInterface
         $apiResource = $this->apiResourceRepository->getByEntity($entity);
         if ($apiResource && $apiResource->getMainItemOperation()) {
             // @todo should be generated with symfony router
-            $iri = str_replace('{id}', $entity->getUid(), $apiResource->getMainItemOperation()->getRoute()->getPath());
+            $iri = str_replace('{id}', (string)$entity->getUid(), $apiResource->getMainItemOperation()->getRoute()->getPath());
             $visitor->visitProperty(
                 new StaticPropertyMetadata(AbstractDomainObject::class, '@id', $iri),
                 $iri

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.4.0",
+        "php": "^7.4.0 || ^8.0.0",
         "ext-json": "*",
         "ext-tokenizer": "*",
         "ext-pdo": "*",
@@ -23,7 +23,7 @@
         "symfony/routing": "^4.1 || ^5.0",
         "symfony/expression-language": "^4.1 || ^5.0",
         "symfony/http-foundation": "^4.2.9 || ^5.0",
-        "symfony/psr-http-message-bridge": "^1.2",
+        "symfony/psr-http-message-bridge": "^2.1",
         "symfony/property-info": "^4.4 || ^5.0",
         "symfony/mime": "^4.4 || ^5.0",
         "symfony/cache": "^4.4 || ^5.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,8 +10,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.2.2',
     'constraints' => [
         'depends' => [
-            'php' => '7.2.0-7.4.99',
-            'typo3' => '8.7.0-10.4.99',
+            'php' => '7.4.0-8.0.99',
+            'typo3' => '10.4.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -89,7 +89,7 @@ call_user_func(
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['t3api']['cors']['maxAge'] = 0;
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['t3api']['cors']['originRegex'] = false;
 
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['t3api'])) {
+        if (!array_key_exists('t3api', $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'])) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['t3api'] = [
                 'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
                 'backend' => \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class,


### PR DESCRIPTION
This patch adds support for PHP 8. It is essentially small code fixes, with one potentially more important change, which is about requesting `symfony/psr-http-message-bridge` at version "2.1" rather than "1.2".