### PR TITLE
Feature: Write generated spec files to path

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=basic/enable; type=string; label=If set, the extension will write generated spec files to this path (absolute).
+spec_files_path=


### PR DESCRIPTION
Since this is the first extension config, I used a try-catch. I'm not so sure if the controller is the best place for this. But putting this into the builder seemed a bit overkill.

solves #73 