### PR TITLE
[FIX] Do not convert empty string to absolute url

### DIFF
--- a/Classes/Serializer/Handler/TypolinkHandler.php
+++ b/Classes/Serializer/Handler/TypolinkHandler.php
@@ -35,6 +35,9 @@ class TypolinkHandler extends AbstractHandler implements SerializeHandlerInterfa
         array $type,
         SerializationContext $context
     ) {
+        if (empty($typolinkParameter)) {
+            return '';
+        }
         return UrlService::forceAbsoluteUrl(
             $this->getContentObjectRenderer()->getTypoLink_URL(...(array)$typolinkParameter),
             $context->getAttribute('TYPO3_SITE_URL')


### PR DESCRIPTION
Passing empty string to UrlService::forceAbsoluteUrl returns url to base domain