### PR TITLE
Make OpenApi specification file valid

### DIFF
--- a/Classes/Service/OpenApiBuilder.php
+++ b/Classes/Service/OpenApiBuilder.php
@@ -7,6 +7,7 @@ use DateTime;
 use Exception;
 use GoldSpecDigital\ObjectOrientedOAS\Exceptions\InvalidArgumentException as OasInvalidArgumentException;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Components;
+use GoldSpecDigital\ObjectOrientedOAS\Objects\Info;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Parameter;
@@ -63,10 +64,21 @@ class OpenApiBuilder
 
         return OpenApi::create()
             ->openapi(OpenApi::OPENAPI_3_0_2)
+            ->info(self::getInfo())
             ->servers(...self::getServers())
             ->tags(...self::getTags($apiResources))
             ->paths(...self::getPaths($apiResources))
             ->components(self::$components);
+    }
+
+    private static function getInfo(): Info
+    {
+        $siteConfig = SiteService::getCurrent()->getConfiguration();
+        $info = new Info();
+        return $info
+            ->title($siteConfig['routeEnhancers']['T3api']['title'] ?? '')
+            ->description($siteConfig['routeEnhancers']['T3api']['description'] ?? '')
+            ->version($siteConfig['routeEnhancers']['T3api']['version'] ?? '');
     }
 
     /**

--- a/Classes/Service/OpenApiBuilder.php
+++ b/Classes/Service/OpenApiBuilder.php
@@ -229,9 +229,11 @@ class OpenApiBuilder
 
             /** @var Parameter $filterParameter */
             foreach ($filterParameters as $filterParameter) {
-                $parameters[] = $filterParameter->in(Parameter::IN_QUERY);
+                $parameters[$filterParameter->name] = $filterParameter->in(Parameter::IN_QUERY);
             }
         }
+
+        sort($parameters);
 
         return $parameters;
     }


### PR DESCRIPTION
This pull request addresses two key issues related to the OpenAPI specification:

1. Fixing Duplicate Parameter Names:

Resolved an issue where the SearchFilter with multiple properties caused duplicate parameter names within the OpenAPI spec. This update ensures adherence to API specification guidelines by eliminating multiple instances of defined parameter names.

2. Implemented the addition of essential meta information to the OpenAPI spec.

Ensured that the 'title' and 'version' fields within the info object are properly set. They are now populated with empty strings to comply with the valid spec requirements.

Thank you for your review and consideration.