### PR TITLE
[FEATURE] Custom OpenAPI schema identifier

### DIFF
--- a/Classes/Domain/Model/ApiResource.php
+++ b/Classes/Domain/Model/ApiResource.php
@@ -36,10 +36,12 @@ class ApiResource
 
     protected OpenApiSettings $openApiSettings;
 
-    public function __construct(string $entity, ApiResourceAnnotation $apiResourceAnnotation)
+    public function __construct(string $entity, ?ApiResourceAnnotation $apiResourceAnnotation = null)
     {
         $this->entity = $entity;
         $this->routes = new RouteCollection();
+
+        $apiResourceAnnotation = $apiResourceAnnotation ?? new ApiResourceAnnotation([]);
 
         $attributes = $apiResourceAnnotation->getAttributes();
         $this->pagination = Pagination::create($attributes);

--- a/Classes/Domain/Model/OpenApiSettings.php
+++ b/Classes/Domain/Model/OpenApiSettings.php
@@ -12,6 +12,8 @@ class OpenApiSettings extends AbstractOperationResourceSettings
 
     protected string $tagDescription = '';
 
+    protected string $schemaIdentifier = '';
+
     /**
      * @param OpenApiSettings|null $base
      * @return OpenApiSettings
@@ -22,8 +24,10 @@ class OpenApiSettings extends AbstractOperationResourceSettings
         string $entityName = ''
     ): AbstractOperationResourceSettings {
         $settings = parent::create($attributes);
-        $settings->tagName = $attributes['title'] ?? $settings->tagName;
-        $settings->tagDescription = $attributes['description'] ?? $settings->tagDescription;
+        $settings->entityName = $entityName;
+        $settings->tagName = $attributes['tagName'] ?? $settings->tagName;
+        $settings->tagDescription = $attributes['tagDescription'] ?? $settings->tagDescription;
+        $settings->schemaIdentifier = $attributes['schemaIdentifier'] ?? $settings->schemaIdentifier;
 
         return $settings;
     }
@@ -42,5 +46,13 @@ class OpenApiSettings extends AbstractOperationResourceSettings
             return $this->tagDescription;
         }
         return sprintf('Operations about %s', $this->entityName);
+    }
+
+    public function getSchemaIdentifierForMode(string $mode): string
+    {
+        if ($this->schemaIdentifier !== '') {
+            return $this->schemaIdentifier . '__' . $mode;
+        }
+        return str_replace('\\', '.', $this->entityName) . '__' . $mode;
     }
 }


### PR DESCRIPTION
When generating API clients with [swagger codegen](https://github.com/swagger-api/swagger-codegen), the resulting model names are pretty unhandy. It would be nice if one could modify the resulting Schema Identifier. 

This PR adds a new `OpenApiSetting` which can be configured via the `@T3api\ApiResource(attributes.openApi)` annotation.

