### PR TITLE
[TASK] Mark nullable parameters explicit

### DIFF
--- a/Classes/Dispatcher/AbstractDispatcher.php
+++ b/Classes/Dispatcher/AbstractDispatcher.php
@@ -56,7 +56,7 @@ abstract class AbstractDispatcher
     public function processOperationByRequest(
         RequestContext $requestContext,
         Request $request,
-        ResponseInterface &$response = null
+        ?ResponseInterface &$response = null
     ): string {
         foreach ($this->apiResourceRepository->getAll() as $apiResource) {
             try {
@@ -90,7 +90,7 @@ abstract class AbstractDispatcher
         OperationInterface $operation,
         array $route,
         Request $request,
-        ResponseInterface &$response = null
+        ?ResponseInterface &$response = null
     ): string {
         $handlers = $this->getHandlersSupportingOperation($operation, $request);
 

--- a/Classes/Exception/AbstractException.php
+++ b/Classes/Exception/AbstractException.php
@@ -20,7 +20,7 @@ abstract class AbstractException extends \Exception implements ExceptionInterfac
      */
     protected string $title;
 
-    protected static function translate(string $key, array $arguments = null): ?string
+    protected static function translate(string $key, ?array $arguments = null): ?string
     {
         return LocalizationUtility::translate($key, 't3api', $arguments);
     }

--- a/Classes/Service/RouteService.php
+++ b/Classes/Service/RouteService.php
@@ -34,7 +34,7 @@ class RouteService implements SingletonInterface
             . '/' . ltrim(self::getFullApiBasePath(), '/');
     }
 
-    public static function routeHasT3ApiResourceEnhancerQueryParam(ServerRequestInterface $request = null): bool
+    public static function routeHasT3ApiResourceEnhancerQueryParam(?ServerRequestInterface $request = null): bool
     {
         $request = $request ?? self::getRequest();
         return $request instanceof ServerRequest && is_array($request->getQueryParams())


### PR DESCRIPTION
This PR fixes some PHP 8.4 deprecation messages
```
Implicitly marking parameter $response as nullable is deprecated, the explicit nullable type must be used instead
```
