### PR TITLE
[BUG] Trim colon from binds to prevent `Named parameter "text_ma_xxx" does not have a bound value` error on matchAgainst search

### DIFF
--- a/Classes/Filter/SearchFilter.php
+++ b/Classes/Filter/SearchFilter.php
@@ -36,7 +36,7 @@ class SearchFilter extends AbstractFilter implements OpenApiSupportingFilterInte
      */
     public function filterProperty(
         string $property,
-        $values,
+               $values,
         QueryInterface $query,
         ApiFilter $apiFilter
     ): ?ConstraintInterface {
@@ -82,6 +82,7 @@ class SearchFilter extends AbstractFilter implements OpenApiSupportingFilterInte
         $binds = [];
         $rootAlias = 'o';
         $queryExpansion = (bool)$apiFilter->getArgument('withQueryExpansion');
+        $booleanQuery = (bool)$apiFilter->getArgument('withBooleanQuery');
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable($tableName);
@@ -100,16 +101,43 @@ class SearchFilter extends AbstractFilter implements OpenApiSupportingFilterInte
 
         foreach ($values as $i => $value) {
             $key = ':text_ma_' . ((int)$i);
-            $conditions[] = sprintf(
-                'MATCH(%s) AGAINST (%s IN NATURAL LANGUAGE MODE %s)',
-                $queryBuilder->quoteIdentifier(
-                    $tableAlias . '.' . GeneralUtility::makeInstance(DataMapper::class)
-                        ->convertPropertyNameToColumnName($propertyName, $apiFilter->getFilterClass())
-                ),
-                $key,
-                $queryExpansion ? ' WITH QUERY EXPANSION ' : ''
-            );
-            $binds[ltrim($key, ':')] = $value;
+
+            if ($booleanQuery) {
+                // Split the value into individual words and create OR conditions
+                $words = explode(' ', trim($value));
+                $booleanQuery = '';
+                foreach ($words as $word) {
+                    if (!empty(trim($word))) {
+                        $booleanQuery .= trim($word) . '* ';
+                    }
+                }
+                $booleanQuery = trim($booleanQuery);
+
+                // use IN BOOLEAN MODE to search for partials of words
+                $conditions[] = sprintf(
+                    'MATCH(%s) AGAINST (%s IN BOOLEAN MODE)',
+                    $queryBuilder->quoteIdentifier(
+                        $tableAlias . '.' . GeneralUtility::makeInstance(DataMapper::class)
+                            ->convertPropertyNameToColumnName($propertyName, $apiFilter->getFilterClass())
+                    ),
+                    $key
+                );
+
+                $binds[ltrim($key, ':')] = $booleanQuery;
+            } else {
+                // Original natural language mode query
+                $conditions[] = sprintf(
+                    'MATCH(%s) AGAINST (%s IN NATURAL LANGUAGE MODE %s)',
+                    $queryBuilder->quoteIdentifier(
+                        $tableAlias . '.' . GeneralUtility::makeInstance(DataMapper::class)
+                            ->convertPropertyNameToColumnName($propertyName, $apiFilter->getFilterClass())
+                    ),
+                    $key,
+                    $queryExpansion ? ' WITH QUERY EXPANSION ' : ''
+                );
+
+                $binds[ltrim($key, ':')] = $value;
+            }
         }
 
         return $queryBuilder

--- a/Classes/Filter/SearchFilter.php
+++ b/Classes/Filter/SearchFilter.php
@@ -109,7 +109,7 @@ class SearchFilter extends AbstractFilter implements OpenApiSupportingFilterInte
                 $key,
                 $queryExpansion ? ' WITH QUERY EXPANSION ' : ''
             );
-            $binds[$key] = $value;
+            $binds[ltrim($key, ':')] = $value;
         }
 
         return $queryBuilder

--- a/Classes/Filter/SearchFilter.php
+++ b/Classes/Filter/SearchFilter.php
@@ -108,7 +108,7 @@ class SearchFilter extends AbstractFilter implements OpenApiSupportingFilterInte
                 $booleanQuery = '';
                 foreach ($words as $word) {
                     if (!empty(trim($word))) {
-                        $booleanQuery .= trim($word) . '* ';
+                        $booleanQuery .= ' +'. trim($word) . '* ';
                     }
                 }
                 $booleanQuery = trim($booleanQuery);


### PR DESCRIPTION
While testing the `matchAgainst` strategy, i ran into the following error: `Named parameter "text_ma_0" does not have a bound value`. This results in the SearchFilter with matchAgainst being un-useable.

This seems to happen as the binds are getting added to the QueryBuilder. To fix this problem, the colon which is previously used for the parameter, needs to be removed before adding it to the Query.

Tested on macOS 15.5 with TYPO3 13.4.14 and PHP 8.3.

