### PR TITLE
Release 5.0.0 cli fixes

### DIFF
--- a/Classes/Routing/Enhancer/ResourceEnhancer.php
+++ b/Classes/Routing/Enhancer/ResourceEnhancer.php
@@ -31,11 +31,22 @@ class ResourceEnhancer extends AbstractEnhancer implements RoutingEnhancerInterf
      */
     public function enhanceForMatching(RouteCollection $collection): void
     {
+        try {
+            $basePath = $this->getBasePath();
+        } catch (\Throwable) {
+            // The T3api base path cannot be resolved when the current site is not
+            // determinable, e.g. in CLI sub-requests such as EXT:solr v14 page indexing
+            // where ServerRequestFactory::fromGlobals() has no valid request URL. The
+            // API routes are irrelevant for such requests, so skip enhancement instead
+            // of breaking route matching for the whole request.
+            return;
+        }
+
         /** @var Route $variant */
         $variant = clone $collection->get('default');
-        $variant->setPath($this->getBasePath() . sprintf('/{%s?}', self::PARAMETER_NAME));
+        $variant->setPath($basePath . sprintf('/{%s?}', self::PARAMETER_NAME));
         $variant->setRequirement(self::PARAMETER_NAME, '.*');
-        $collection->add('enhancer_' . $this->getBasePath() . spl_object_hash($variant), $variant);
+        $collection->add('enhancer_' . $basePath . spl_object_hash($variant), $variant);
     }
 
     /**

--- a/Classes/Service/SiteService.php
+++ b/Classes/Service/SiteService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SourceBroker\T3api\Service;
 
 use SourceBroker\T3api\Routing\Enhancer\ResourceEnhancer;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Http\ServerRequestFactory;
 use TYPO3\CMS\Core\Routing\SiteMatcher;
@@ -69,7 +70,11 @@ class SiteService
 
     protected static function getResolvedByTypo3(): ?SiteInterface
     {
-        if (!class_exists(SiteMatcher::class)) {
+        // On CLI there is no valid request URL, so ServerRequestFactory::fromGlobals()
+        // throws InvalidRequestUrlOnCliException. That breaks any consumer which triggers
+        // route-enhancer matching inside a CLI sub-request (e.g. EXT:solr v14 indexing).
+        // Returning null lets the URL / wildcard fallbacks below resolve the site instead.
+        if (!class_exists(SiteMatcher::class) || Environment::isCli()) {
             return null;
         }
 

--- a/Classes/Service/SiteService.php
+++ b/Classes/Service/SiteService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SourceBroker\T3api\Service;
 
 use SourceBroker\T3api\Routing\Enhancer\ResourceEnhancer;
-use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Http\ServerRequestFactory;
 use TYPO3\CMS\Core\Routing\SiteMatcher;
@@ -70,11 +69,7 @@ class SiteService
 
     protected static function getResolvedByTypo3(): ?SiteInterface
     {
-        // On CLI there is no valid request URL, so ServerRequestFactory::fromGlobals()
-        // throws InvalidRequestUrlOnCliException. That breaks any consumer which triggers
-        // route-enhancer matching inside a CLI sub-request (e.g. EXT:solr v14 indexing).
-        // Returning null lets the URL / wildcard fallbacks below resolve the site instead.
-        if (!class_exists(SiteMatcher::class) || Environment::isCli()) {
+        if (!class_exists(SiteMatcher::class)) {
             return null;
         }
 


### PR DESCRIPTION
Fix route enhancer failures during CLI sub-requests (e.g. EXT:solr v14 indexing)                
                                                                                                  
  When TYPO3's route matching runs inside a CLI context — such as EXT:solr v14 page indexing,     
  which triggers a sub-request without a real HTTP request URL —                                  
  ServerRequestFactory::fromGlobals() throws InvalidRequestUrlOnCliException. This happened       
  because SiteService::getResolvedByTypo3() unconditionally called it while trying to resolve the 
  current site.                                                                                   
                                                                                                  
  This surfaced downstream in ResourceEnhancer::enhanceForMatching(): getBasePath() depends on the
  current site being resolvable, so the exception propagated and broke route matching for the     
  entire request — not just the T3api routes.                                                     
                                                                                                  
  Changes                                                                                         
                                                                                                  
  - Classes/Routing/Enhancer/ResourceEnhancer.php: wrap getBasePath() in enhanceForMatching() in a
  try/catch — if the base path can't be resolved (no current site), skip T3api enhancement for    
  that request instead of throwing. The API routes are irrelevant in that case anyway.            
  - Classes/Service/SiteService.php: no net change — this was addressed directly in the enhancer  
  instead, since catching there covers the failure at its actual point of impact.                 
                                                                                                  
  Testing                                                                                         
                                                                                                  
  Verified route matching no longer throws during a CLI sub-request lacking a request URL, while  
  normal HTTP request handling is unaffected.